### PR TITLE
Deploy: don't clean containers until the new image is built.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PROJECT = dockership
 COMMANDS = dockership dockershipd
 DEPENDENCIES = gopkg.in/check.v1 \
-code.google.com/p/go.tools/cmd/cover \
+golang.org/x/tools/cmd/cover \
 github.com/jteeuwen/go-bindata/... \
 github.com/gorilla/mux \
 github.com/laher/goxc

--- a/core/docker.go
+++ b/core/docker.go
@@ -48,11 +48,16 @@ func NewDocker(endPoint string, env *Environment) (*Docker, error) {
 
 func (d *Docker) Deploy(p *Project, rev Revision, dockerfile *Dockerfile, output io.Writer, force bool) error {
 	Debug("Deploying dockerfile", "project", p, "revision", rev, "end-point", d.endPoint)
-	if err := d.Clean(p); err != nil {
+
+	if err := d.cleanImages(p); err != nil {
 		return err
 	}
 
 	if err := d.BuildImage(p, rev, dockerfile, output); err != nil {
+		return err
+	}
+
+	if err := d.cleanContainers(p); err != nil {
 		return err
 	}
 

--- a/core/docker.go
+++ b/core/docker.go
@@ -182,7 +182,7 @@ func (d *Docker) ListContainers(p *Project) ([]*Container, error) {
 func (d *Docker) ListImages(p *Project) ([]*Image, error) {
 	Debug("Retrieving current containers", "project", p, "end-point", d.endPoint)
 
-	l, err := d.client.ListImages(true)
+	l, err := d.client.ListImages(docker.ListImagesOptions{All: true})
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change just pushes cleaning the previous containers on deploy until after the new image is built.

Also, updated dependencies.