### PR TITLE
Volumes and VolumesFrom feature

### DIFF
--- a/core/docker.go
+++ b/core/docker.go
@@ -290,7 +290,8 @@ func (d *Docker) startContainer(p *Project, c *Container) error {
 		PortBindings:  ports,
 		RestartPolicy: restartPolicy,
 		Links:         d.formatLinks(p.Links),
-		VolumesFrom:   p.Volumes,
+		VolumesFrom:   p.VolumesFrom,
+		Binds:         p.Binds,
 	})
 }
 

--- a/core/project.go
+++ b/core/project.go
@@ -29,7 +29,8 @@ type Project struct {
 	NoCache             bool
 	Restart             string
 	Ports               []string         `gcfg:"Port"`
-	Volumes             []string         `gcfg:"Volume"`
+	Binds               []string         `gcfg:"Volume"`
+	VolumesFrom         []string         `gcfg:"VolumeFrom"`
 	Links               map[string]*Link `json:"-"`
 	LinkNames           []LinkDefinition `gcfg:"Link"`
 	LinkedBy            []*Project       `json:"-"`

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -74,6 +74,7 @@ An environment is a logical group of any number of Docker servers. Dockership su
 * `Restart` (optional, default: no): restart policy to apply when a container exits (no, on-failure[:max-retry], always)  (like --restart at `docker run`)
 * `Link` (multiple, optional): creates a Link to other project, when this project is deployed the linked projects are restarted (like -P at `docker run`)
 * `Volume` (multiple, optional): mounts a Data Volume Container (like -v at `docker run`)
+* `VolumeFrom` (multiple, optional): mounts a Data Volumes From  a specified container (like --volumes-from at `docker run`)
 * `GithubToken` (default: Global.GithubToken): the token needed to access this repository, if it is different from the global one.
 * `Environment` (multiple, mandatory): Environment name where this project could be deployed
 * `WebHook` (optional): An HTTP address. See [Extending Dockership](https://github.com/mcuadros/dockership/blob/master/documentation/extending_dockership.md#web-hooks) for details.


### PR DESCRIPTION
In fact docker api is a little jungle ;) Volumes are not volumes but Binds.

I've checked on my local it works fine. 
here is an example of conf file 

...
```ini
[Project "d3-lamp"]
Repository = git@github.com:alterway/d3lamp.git
Environment = dev
Port = 0.0.0.0:80:80/tcp
Port = 0.0.0.0:443:443/tcp
Volume = /Users/hleclerc/tmp/src/d3lamp:/var/www/html

[Project "v-from-d3lamp"]
Repository = git@github.com:alterway/d3fromlamp.git
Environment = dev
Port = 0.0.0.0:9090:9090/tcp
VolumeFrom = d3-lamp


[Environment "dev"]
DockerEndPoint = tcp://192.168.59.103:2376
CertPath = /etc/dockership/certs
```